### PR TITLE
Remove duplicate dependency on Rails to prevent RubyGems error.

### DIFF
--- a/themes_for_rails.gemspec
+++ b/themes_for_rails.gemspec
@@ -21,5 +21,4 @@ Gem::Specification.new do |gem|
   gem.add_development_dependency "test-unit"
   gem.add_development_dependency "contest"
   gem.add_development_dependency "mocha"
-  gem.add_development_dependency('rails', ["= 3.0.11"])
 end


### PR DESCRIPTION
See https://github.com/rubygems/rubygems/blob/master/lib/rubygems/specification.rb#L2795
